### PR TITLE
search through items

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,9 @@
   "editor.detectIndentation": false,
   "editor.formatOnPaste": true,
   "editor.formatOnSave": true,
+  "editor.rulers": [
+    140
+  ],
   "editor.tabSize": 2,
   "editor.tabCompletion": true,
   "editor.wordBasedSuggestions": false,
@@ -23,5 +26,10 @@
     "editor.codeActionsOnSave": {
       "source.organizeImports": true
     }
+  },
+  "javascript.preferences.quoteStyle": "single",
+  "typescript.preferences.quoteStyle": "single",
+  "workbench.colorCustomizations": {
+    "editorRuler.foreground": "#ff4081"
   }
 }

--- a/src/app/content/components/category-list/category-list.component.html
+++ b/src/app/content/components/category-list/category-list.component.html
@@ -44,6 +44,7 @@
           <tr *ngFor="let item of c.items"
             app-item
             [item]="item"
+            [searchFor]="searchFor$ | async"
             (updateItem)="updateItem($event)"
             (removeItem)="removeItem($event)"
           >

--- a/src/app/content/components/item/item.component.html
+++ b/src/app/content/components/item/item.component.html
@@ -1,6 +1,6 @@
 <td data-th="Name:" class="cell">
   <a *ngIf="item.url" [href]="item.url" target="_blank" [matTooltip]="item.name">{{item.name}}</a>
-  <span *ngIf="!item.url">{{item.name}}</span>
+  <span *ngIf="!item.url" [innerHTML]="item.name | highlight: searchFor"></span>
 </td>
 
 <td data-th="Account:" ngxClipboard [cbContent]="item.account" (cbOnSuccess)="copied()" class="cell" [matTooltip]="item.account">

--- a/src/app/content/components/item/item.component.ts
+++ b/src/app/content/components/item/item.component.ts
@@ -28,6 +28,7 @@ export class DeleteItemDialogComponent {
 })
 export class ItemComponent implements OnInit {
   @Input() item: IItem;
+  @Input() searchFor: string;
   @Output() updateItem = new EventEmitter<IUpdateItemPayload>(false);
   @Output() removeItem = new EventEmitter<IItem>(false);
 

--- a/src/app/content/state/categories/categories.service.spec.ts
+++ b/src/app/content/state/categories/categories.service.spec.ts
@@ -1,10 +1,10 @@
 import { TestBed } from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material';
+import { BackendMockService, BackendService } from '@app/content/services';
+import { concatMapTo, first, map, skip, tap } from 'rxjs/operators';
+import { CategoriesQuery } from './categories.query';
 import { CategoriesService } from './categories.service';
 import { CategoriesStore } from './categories.store';
-import { CategoriesQuery } from './categories.query';
-import { BackendService, BackendMockService } from '@app/content/services';
-import { MatSnackBar } from '@angular/material';
-import { skip, tap, first, concatMapTo, map } from 'rxjs/operators';
 
 class MatSnackBarMock { }
 
@@ -88,5 +88,18 @@ describe('Categories Store', () => {
 
     service.addItem({ item: { id: -1, name: 'one', category_id: 7 }, auto_pass: false, genopts: {} });
     service.addItem({ item: { id: -1, name: 'two', category_id: 7 }, auto_pass: false, genopts: {} });
+  });
+
+  it('should set searchFor', () => {
+    let searchFor: string | undefined;
+    query.select(s => s.searchFor).subscribe(s => searchFor = s);
+    service.keyPressed('s');
+    expect(searchFor).toBe('s');
+    service.keyPressed('t');
+    expect(searchFor).toBe('st');
+    service.keyPressed('Backspace');
+    expect(searchFor).toBe('s');
+    service.keyPressed('Escape');
+    expect(searchFor).toBe('');
   });
 });

--- a/src/app/content/state/categories/categories.service.ts
+++ b/src/app/content/state/categories/categories.service.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@angular/core';
-import { CategoriesStore } from './categories.store';
+import { MatSnackBar } from '@angular/material';
+import { IItem, IItemFormResult, IRemoveCategoryPayload, IUpdateCategoryPayload, IUpdateItemPayload } from '@app/content/models';
 import { BackendService } from '@app/content/services/backend.service';
 import { ItemsStore } from '../items';
-import { MatSnackBar } from '@angular/material';
-import { IRemoveCategoryPayload, IUpdateCategoryPayload, IItemFormResult, IUpdateItemPayload, IItem } from '@app/content/models';
+import { CategoriesStore } from './categories.store';
 
 @Injectable({
   providedIn: 'root'
@@ -133,5 +133,23 @@ export class CategoriesService {
 
   setLoading(isLoading: boolean) {
     this.categoriesStore.setLoading(isLoading);
+  }
+
+  keyPressed(key: string) {
+    if (key === 'Escape') {
+      this.categoriesStore.updateRoot({ searchFor: '' });
+    } else if (key === 'Backspace') {
+      this.categoriesStore.updateRoot(s => {
+        if (s.searchFor) {
+          const searchFor = s.searchFor.slice(0, s.searchFor.length - 1);
+          return { searchFor };
+        }
+      });
+    } else {
+      this.categoriesStore.updateRoot(s => {
+        const searchFor = (s.searchFor || '') + key;
+        return { searchFor };
+      });
+    }
   }
 }

--- a/src/app/content/state/categories/categories.store.ts
+++ b/src/app/content/state/categories/categories.store.ts
@@ -1,24 +1,22 @@
 import { Injectable } from '@angular/core';
-import { EntityState, EntityStore, StoreConfig, guid } from '@datorama/akita';
 import { ICategory } from '@app/content/models';
+import { EntityState, EntityStore, guid, StoreConfig } from '@datorama/akita';
 
 export interface CategoriesState extends EntityState<ICategory> {
   ui: {
     isPathPhraseCorrect: boolean
   };
+  searchFor: string;
 }
 
 @Injectable({ providedIn: 'root' })
 @StoreConfig({ name: 'categories' })
 export class CategoriesStore extends EntityStore<CategoriesState, ICategory> {
-  ui: {
-    isPathPhraseCorrect: true
-  };
-
   constructor() {
-    const initialState = {
+    const initialState: CategoriesState = {
       loading: false,
-      ui: { isPathPhraseCorrect: false }
+      ui: { isPathPhraseCorrect: false },
+      searchFor: ''
     };
     super(initialState);
   }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -15,7 +15,7 @@ export const environment: IEnv = {
   baseHref: '',
   isUserNameAutocompleteEnabled: true,
   showTokenExpirationCustomization: true,
-  mockApi: true
+  mockApi: false
 };
 
 /*

--- a/tslint.json
+++ b/tslint.json
@@ -28,7 +28,7 @@
     "interface-over-type-literal": true,
     "label-position": true,
     "max-line-length": [
-      true,
+      false,
       140
     ],
     "member-access": false,


### PR DESCRIPTION
closes #50 

I didn't create a checkbox to enable searching through the items. I just made it a default behavior. I think if you play around with it, you'll see that it feels comfortable and hopefully, you won't feel like you want the old behavior back. If you do, we can certainly make it optional.

Also, currently it only searches through item names. It does not look at account/username/any other field. I think this is reasonable. Let me know what you think.