### PR TITLE
Use a library for url validation.

### DIFF
--- a/src/app/misc/index.ts
+++ b/src/app/misc/index.ts
@@ -6,11 +6,12 @@ export const urlValidator: ValidatorFn = (control: AbstractControl) => {
   }
 
   const v: string = control.value;
-  return /^(?:(?:(?:https?|ftp):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})).?)(?::\d{2,5})?(?:[/?#]\S*)?$/i.test(
-    v
-  )
-    ? null
-    : { url: true };
+  try {
+    new URL(v);
+    return { url: true };
+  } catch (err) {
+    return null;
+  }
 };
 
 export function isPresent(obj: any): boolean {

--- a/src/app/misc/index.ts
+++ b/src/app/misc/index.ts
@@ -8,9 +8,9 @@ export const urlValidator: ValidatorFn = (control: AbstractControl) => {
   const v: string = control.value;
   try {
     new URL(v);
-    return { url: true };
-  } catch (err) {
     return null;
+  } catch (err) {
+    return { url: true };
   }
 };
 


### PR DESCRIPTION
Instead of messy regex pattern, use the built-in method.
This will also allow URLs of type: http://localhost:8088 and http://10.4.2.28.